### PR TITLE
Added ipyleaflet to the list of jupyter extensions installed via mamba.

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN chmod g+w /etc/passwd
 ###############################
 # Non Custom Jupyter Extensions.
 ###############################
-RUN mamba install -c conda-forge plotly=5.5.0 jupyterlab_widgets=1.0.2 jupyterlab-git=0.34.2
+RUN mamba install -c conda-forge plotly=5.5.0 jupyterlab_widgets=1.0.2 jupyterlab-git=0.34.2 ipyleaflet@0.17.2
 RUN jupyter labextension install --no-build jupyterlab-plotly@5.5.0
 # install git extension - needs dev install to modify paths in entrypoint script
 #RUN git clone -b v0.20.0 https://github.com/jupyterlab/jupyterlab-git.git


### PR DESCRIPTION
I've added ipyleaflet to the list of jupyter extensions that are installed to see if this will allow ipyleaflet to be used in notebooks.

The associated ticket for this task is here: https://github.com/MAAP-Project/ZenHub/issues/668