### PR TITLE
added pip install jupyter lab notifications

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -48,6 +48,7 @@ RUN pip install xmltodict
 RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@latest --no-build
 
 RUN pip install -i https://test.pypi.org/simple/ jupyter-server-extension
+RUN pip install jupyterlab_notifications
 RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/hide-che-panel-jupyter-extension@latest --no-build


### PR DESCRIPTION
Added `RUN pip install jupyterlab_notifications` to the dockerfile to test if this package will work in DIT. Note that this package is not working for me locally and also not working installing it in the terminal in DIT. If this doesn't work, I will immediately submit another PR removing this line from the dockerfile 