### PR TITLE
Add ipyleaflet support

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -39,6 +39,7 @@ RUN chmod g+w /etc/passwd
 ###############################
 RUN mamba install -c conda-forge plotly=5.5.0 jupyterlab_widgets=1.0.2 jupyterlab-git=0.34.2 ipyleaflet@0.17.2
 RUN jupyter labextension install --no-build jupyterlab-plotly@5.5.0
+RUN jupyter labextension install --no-build jupyter-leaflet@0.17.2
 RUN npm install typescript -g
 RUN pip install xmltodict
 


### PR DESCRIPTION
This PR introduces an additional installation that is needed for ipyleaflet to function since we are running JupyterLab 2.1.4 in UAT.