### PR TITLE
`devfile.yaml` updates to reference 'develop' branch

### DIFF
--- a/devfiles/edav/devfile/devfile.yaml
+++ b/devfiles/edav/devfile/devfile.yaml
@@ -31,7 +31,7 @@ components:
                 emptyDir: {}
             containers:
               - name: jupyter
-                image: 'mas.dit.maap-project.org/root/maap-workspaces/edav:dit'
+                image: 'mas.dit.maap-project.org/root/maap-workspaces/edav:develop'
                 imagePullPolicy: Always
                 resources:
                   limits:

--- a/devfiles/isce2/devfile/devfile.yaml
+++ b/devfiles/isce2/devfile/devfile.yaml
@@ -31,7 +31,7 @@ components:
                 emptyDir: {}
             containers:
               - name: jupyter
-                image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/isce2:dit'
+                image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/isce2:develop'
                 imagePullPolicy: Always
                 resources:
                   limits:

--- a/devfiles/pangeo/devfile/devfile.yaml
+++ b/devfiles/pangeo/devfile/devfile.yaml
@@ -31,7 +31,7 @@ components:
                 emptyDir: {}
             containers:
               - name: jupyter
-                image: 'mas.dit.maap-project.org/root/maap-workspaces/pangeo/pangeo:dit'
+                image: 'mas.dit.maap-project.org/root/maap-workspaces/pangeo/pangeo:develop'
                 imagePullPolicy: Always
                 resources:
                   limits:

--- a/devfiles/r/devfile/devfile.yaml
+++ b/devfiles/r/devfile/devfile.yaml
@@ -31,7 +31,7 @@ components:
                 emptyDir: {}
             containers:
               - name: jupyter
-                image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/r:dit'
+                image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/r:develop'
                 imagePullPolicy: Always
                 resources:
                   limits:

--- a/devfiles/rgedi/devfile/devfile.yaml
+++ b/devfiles/rgedi/devfile/devfile.yaml
@@ -31,7 +31,7 @@ components:
                 emptyDir: {}
             containers:
               - name: jupyter
-                image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/rgedi:dit'
+                image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/rgedi:develop'
                 imagePullPolicy: Always
                 resources:
                   limits:

--- a/devfiles/vanilla/devfile/devfile.yaml
+++ b/devfiles/vanilla/devfile/devfile.yaml
@@ -31,7 +31,7 @@ components:
                 emptyDir: {}
             containers:
               - name: jupyter
-                image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/vanilla:dit'
+                image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/vanilla:develop'
                 imagePullPolicy: Always
                 resources:
                   limits:


### PR DESCRIPTION
Updated all our workspace devfiles.yaml files to address the renaming of our "dit" branch to "develop".  This PR addresses the resolution for issue [#682](https://github.com/MAAP-Project/ZenHub/issues/682)


Brian and I came to the conclusion that ADE is referencing images that are tagged with "dit" instead of "develop", thereby not allowing us to test updates to our workspaces.