### PR TITLE
Updated pangeo base image

### DIFF
--- a/jupyterlab3-build/docker/Dockerfile
+++ b/jupyterlab3-build/docker/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get clean && apt-get update && \
 
 # Jupyterlab3 does not work with Node 17.x
 # Mamba should be installed in all base images
-RUN mamba install -c conda-forge nodejs=16.13.2 jupyter-packaging=0.11.1
+#RUN mamba install -c conda-forge nodejs=16.13.2 jupyter-packaging=0.11.1
+RUN mamba install -c conda-forge nodejs jupyter-packaging
 
 #ARG NB_USER="ops"
 # Adjust permissions on home directory so writable by group root.


### PR DESCRIPTION
George recommended removing the pinned versions of nodejs and jupyter-packaging to determine if these are causing the issues we are experiencing when building the pangeo workspace.

If the test fails, we'll revert this change.