### PR TITLE
Update Node JS to solve dependency issue with ISCE2

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get clean && apt-get update && \
 
 # Jupyterlab3 does not work with Node 17.x
 # Mamba should be installed in all base images
-RUN mamba install -c conda-forge jupyterlab=3.4.4 nodejs=16.13.2 gitpython=3.1.26 jupyter-packaging=0.11.1
+RUN mamba install -c conda-forge jupyterlab=3.4.4 nodejs=16.14.2 gitpython=3.1.26 jupyter-packaging=0.11.1
 
 #ARG NB_USER="ops"
 # Adjust permissions on home directory so writable by group root.
@@ -37,7 +37,7 @@ RUN chmod g+w /etc/passwd
 ###############################
 # Non Custom Jupyter Extensions.
 ###############################
-RUN mamba install -c conda-forge plotly=5.5.0 jupyterlab_widgets=1.0.2 jupyterlab-git=0.34.2 ipyleaflet=0.17.2 
+RUN mamba install -c conda-forge plotly=5.5.0 jupyterlab_widgets=1.0.2 jupyterlab-git=0.34.2 ipyleaflet=0.17.2
 RUN jupyter labextension install --no-build jupyterlab-plotly@5.5.0
 RUN npm install typescript -g
 RUN pip install xmltodict


### PR DESCRIPTION
Incremented nodejs version by one revision to 16.14.2 to resolve a dependency issue with the isce2 base build. Tested locally and build still goes to completion with this newer version.