### PR TITLE
Add `stac_ipyleaflet` to Pangeo workspace

### DIFF
--- a/jupyterlab3/pangeo/environment.yml
+++ b/jupyterlab3/pangeo/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - pangeo-notebook=2023.04.15
   - gitpython=3.1.30
+  - ipyevents=2.0.1
   - ipyleaflet=0.17.2
   - jupyterlab=3.6.3
   - jupyterlab-git=0.34.2
@@ -12,4 +13,12 @@ dependencies:
   - jupyterlab_widgets=3.0.7
   - nodejs=18.15.0
   - plotly=5.14.1
+  - pydantic=1.10.8 
+  - rioxarray=0.14.1
+  - shapely=2.0.1
   - xmltodict=0.13.0
+  - xarray=2023.5.0
+  - pip:
+    - rio_tiler==4.1.11
+    - pystac_client==0.6.1
+    - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@dev/wug-map-refresh#egg-info=stac_ipyleaflet

--- a/jupyterlab3/pangeo/environment.yml
+++ b/jupyterlab3/pangeo/environment.yml
@@ -21,4 +21,4 @@ dependencies:
   - pip:
     - rio_tiler==4.1.11
     - pystac_client==0.6.1
-    - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@dev/wug-map-refresh#egg-info=stac_ipyleaflet
+    - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.2.0#egg-info=stac_ipyleaflet


### PR DESCRIPTION
This PR addresses the addition of [stac_ipyleaflet](https://github.com/MAAP-Project/stac_ipyleaflet), version [0.2.0](https://github.com/MAAP-Project/stac_ipyleaflet/releases/tag/0.2.0), to our Pangeo workspace. It also includes the addition of packages that were missing as reported by @wildintellect .