### PR TITLE
Fix OpenSSL issue with ISCE3

### DIFF
--- a/base_images/isce3/docker/Dockerfile
+++ b/base_images/isce3/docker/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /projects
 RUN sed -i -e 's/\/root/\/projects/g' /etc/passwd
 
 RUN conda install -y -c conda-forge mamba=1.4.2
+RUN pip install pyOpenSSL==23.2.0
 
 RUN mamba install -y -c conda-forge isce3=0.12.0 xarray=2023.4.2 \
     hvplot=0.8.3 fsspec=2023.5.0 scikit-learn=1.2.2 && \


### PR DESCRIPTION
Added installation of newer version of OpenSSL to fix issue with mamba installing an older version of the package.

This is the same fix used to fix the same issue for the R and ISCE2 workspaces.