### PR TITLE
updated version of maap libs jupyter extension

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -58,7 +58,7 @@ RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.1.1 --no-build
 RUN jupyter labextension install @maap-jupyterlab/umf-jupyter-extension@1.0.0 --no-build
-RUN jupyter labextension install @maap-jupyterlab/maap-libs-jupyter-extension@1.0.1 --no-build
+RUN jupyter labextension install @maap-jupyterlab/maap-libs-jupyter-extension@1.0.2 --no-build
 RUN jupyter labextension install @maap-jupyterlab/edsc-jupyter-extension@1.0.4 --no-build
 RUN jupyter labextension install @maap-jupyterlab/user-workspace-management-jupyter-extension@0.0.3 --no-build
 RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@0.0.46 --no-build


### PR DESCRIPTION
Updating maap libs jupyter extension, which had the following changes:

Changed from INotifications to Notification from the @jupyterlab/apputil package
Also, changed maapsec/environment to jupyter-server-extension/getConfig so now using the MAAP icon works correctly adding the api_server when creating a MAAP instance
ie
```
from maap.maap import MAAP
maap = MAAP(maap_host='api.dit.maap-project.org')
```
Created a vanilla image to test here: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/vanilla:jlab-notifs-maap-libs'