### PR TITLE
Added memory extension

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN echo "Checking if environment.yml exists for ${BASE_IMAGE_TYPE}" \
 
 RUN npm install typescript -g
 RUN pip install jupyter-server==2.5.0
+RUN pip install jupyter-resource-usage==0.7.2
 
 # Adjust permissions on home directory so writable by group root.
 RUN chgrp -Rf root /home/$NB_USER && chmod -Rf g+w /home/$NB_USER

--- a/jupyterlab3/entrypoint.sh
+++ b/jupyterlab3/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # A more robust method of constructing the workspace url prefix
-get_workspace_url_prefix() {
+get_request_data() {
 	python3 - <<END
 import os
 import json
@@ -13,11 +13,10 @@ namespace = "$1"
 # Replicate Che's namespace converter policy
 # by substituting any non-alphanumeric characters with hyphens.
 namespace = re.sub("[^0-9a-zA-Z-]+", "-", namespace)
+api_endpoint = "$2"
 
 svc_host = os.environ.get('KUBERNETES_SERVICE_HOST')
 svc_host_https_port = os.environ.get('KUBERNETES_SERVICE_PORT_HTTPS')
-che_workspace_id = os.environ.get('CHE_WORKSPACE_ID')
-che_machine_name = os.environ.get('CHE_MACHINE_NAME').lower().replace('/', '-')
 
 with open ("/var/run/secrets/kubernetes.io/serviceaccount/token", "r") as t:
     token=t.read()
@@ -26,12 +25,25 @@ headers = {
     'Authorization': 'Bearer ' + token,
 }
 
-request_string = 'https://' + svc_host + ':' + svc_host_https_port + '/api/v1/namespaces/' + namespace +  '/endpoints/'
+request_string = 'https://' + svc_host + ':' + svc_host_https_port + '/api/v1/namespaces/' + namespace +  '/' + api_endpoint + '/'
 httprequest = Request(request_string, headers=headers)
 context = ssl._create_unverified_context()
 with urlopen(httprequest, context=context) as raw_response:
     response = raw_response.read().decode()
 data = json.loads(response)
+print(data)
+
+END
+}
+
+# A more robust method of constructing the workspace url prefix
+get_workspace_url_prefix() {
+	python3 - <<END
+data=$(get_request_data "$1" "endpoints")
+
+import os
+che_workspace_id = os.environ.get('CHE_WORKSPACE_ID')
+che_machine_name = os.environ.get('CHE_MACHINE_NAME').lower().replace('/', '-')
 
 endpoints = data['items']
 for endpoint in endpoints:
@@ -39,6 +51,7 @@ for endpoint in endpoints:
         if che_workspace_id == endpoint['metadata']['labels']['che.workspace_id']:
             print("/%s/%s" % (endpoint['metadata']['name'], endpoint['subsets'][0]['ports'][0]['name']))
             break
+
 END
 }
 
@@ -46,13 +59,16 @@ for i in {1..300}
 do
     echo "Attempt $i to construct PREVIEW_URL"
     PREVIEW_URL=$(get_workspace_url_prefix "$CHE_WORKSPACE_NAMESPACE-che") # Che 7 OPS configuration where the (actual) namespace is "<username>-che"
+    NAMESPACE="$CHE_WORKSPACE_NAMESPACE-che"
     if test -z "$PREVIEW_URL"
     then
         PREVIEW_URL=$(get_workspace_url_prefix "$CHE_WORKSPACE_NAMESPACE-$CHE_WORKSPACE_ID") # Che 7 UAT configuration fallback where the default namespace is "<username>-<workspaceid>", this will be deprecated
+        NAMESPACE="$CHE_WORKSPACE_NAMESPACE-$CHE_WORKSPACE_ID"
     fi
     if test -z "$PREVIEW_URL"
     then
         PREVIEW_URL=$(get_workspace_url_prefix "$CHE_WORKSPACE_ID") # Che 6 configuration fallback where the default namespace is the workspace id, this will be deprecated
+        NAMESPACE="$CHE_WORKSPACE_ID"
     fi
     if ! test -z "$PREVIEW_URL" # exit loop when it has a preview_url
     then
@@ -115,13 +131,35 @@ mkdir -p /projects/.ssh/
 chmod 700 /projects/.ssh/
 service ssh restart
 
+# Get maximum memory allocation for this workspace to display at bottom of notebook
+get_max_memory() {
+	python3 - <<END
+data_pods=$(get_request_data "$1" "pods")
+
+import os
+import sys
+che_workspace_id = os.environ.get('CHE_WORKSPACE_ID')
+
+for item in data_pods['items']: 
+    if che_workspace_id == item['metadata']['labels'].get('che.workspace_id'):
+        for container in item['spec']['containers']:
+            if container['name']=="jupyter":
+                print(container['resources']['limits']['memory'])
+                sys.exit()
+
+print(8489271296) #default memory
+END
+}
+
+MEMORY=$(get_max_memory "$NAMESPACE")
+
 # TBD maap-py install
 
 VERSION=$(jupyter lab --version)
 if [[ $VERSION > '2' ]] && [[ $VERSION < '3' ]]; then
     SHELL=/bin/bash jupyter lab --ip=0.0.0.0 --port=3100 --allow-root --NotebookApp.token='' --NotebookApp.base_url=$PREVIEW_URL --no-browser --debug
 elif [[ $VERSION > '3' ]] && [[ $VERSION < '4' ]]; then
-    SHELL=/bin/bash jupyter lab --ip=0.0.0.0 --port=3100 --allow-root --ContentsManager.allow_hidden=True --ServerApp.token='' --ServerApp.base_url=$PREVIEW_URL --no-browser --debug --ServerApp.disable_check_xsrf=True
+    SHELL=/bin/bash jupyter lab --ip=0.0.0.0 --port=3100 --allow-root --ContentsManager.allow_hidden=True --ServerApp.token='' --ServerApp.base_url=$PREVIEW_URL --no-browser --debug --ServerApp.disable_check_xsrf=True --ResourceUseDisplay.mem_limit=$MEMORY --ResourceUseDisplay.mem_warning_threshold=0.2
 else
     echo "Error! Jupyterlab version not supported."
 fi


### PR DESCRIPTION
Added a memory extension which tells the user how much memory they are currently using for a workspace out of how much available energy. The icon will turn red if they only have 20% of memory left. The maximum memory allocation is found in the entrypoint.sh (extracted from what the user put in the devfile)
<img width="600" alt="Screenshot 2023-08-02 at 12 02 56 PM" src="https://github.com/MAAP-Project/maap-workspaces/assets/114033465/7b1df127-cdb9-4b86-9e9e-33b49fffa465">
<img width="416" alt="Screenshot 2023-08-02 at 1 07 31 PM" src="https://github.com/MAAP-Project/maap-workspaces/assets/114033465/9fd143cb-25b4-4704-aeff-dee2df250128">

Build for all base images here: https://repo.dit.maap-project.org/root/maap-workspaces/-/pipelines/3224, vanilla successful in this one with same code: https://repo.dit.maap-project.org/root/maap-workspaces/-/pipelines/3231
Rgedi failing is unrelated

Tried building workspaces in DIT for all images but rgedi, and all contain the memory extension

Completes: https://github.com/MAAP-Project/Community/issues/749