### PR TITLE
Feature/update maap help tour

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN jupyter labextension install @maap-jupyterlab/umf-jupyter-extension@1.0.0 --
 RUN jupyter labextension install @maap-jupyterlab/maap-libs-jupyter-extension@1.0.2 --no-build
 RUN jupyter labextension install @maap-jupyterlab/edsc-jupyter-extension@1.0.4 --no-build
 RUN jupyter labextension install @maap-jupyterlab/user-workspace-management-jupyter-extension@0.0.3 --no-build
-RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@0.0.46 --no-build
+RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@1.0.0 --no-build
 RUN jupyter labextension install @maap-jupyterlab/che-sidebar-visibility-jupyter-extension@1.0.1 --no-build
 
 RUN jupyter lab build && \


### PR DESCRIPTION
Upgrading to version 1.0.0 of maap help jupyter extension

The latest release removed collaborators from the tour (which was causing it to skip a step before since we removed collaborators from the ADE), and added highlighting the memory extension to the tour 
<img width="385" alt="Screenshot 2023-08-10 at 3 14 07 PM" src="https://github.com/MAAP-Project/maap-workspaces/assets/114033465/e35c89ce-e3ea-4965-aeb0-af20e59bc4cb">

This release also switches from INotifications to @jupyterlab/apputils Notifications 

Successful job building vanilla image with this branch: https://repo.dit.maap-project.org/root/maap-workspaces/-/jobs/6558

Completes: https://github.com/MAAP-Project/Community/issues/618 