### PR TITLE
Feature/libmamba solver

### DIFF
--- a/base_images/isce2/docker/Dockerfile
+++ b/base_images/isce2/docker/Dockerfile
@@ -30,12 +30,13 @@ RUN mkdir /projects
 WORKDIR /projects
 RUN sed -i -e 's/\/root/\/projects/g' /etc/passwd
 
-RUN conda install -y -c conda-forge mamba=1.3.1
-RUN pip install pyOpenSSL==23.2.0
+RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
+    conda install -y -n base conda-libmamba-solver && \
+    conda config --set solver libmamba
 
 # need to uninstall jupyter_server_terminals as it conflicts with Jupyterlab 3.4.x. Doesn't seem to break anything
 # but can get rid of if/when we upgrade jlab
-RUN mamba install -y -c conda-forge -c plant plant=0.1.89dev isce2=2.6.2 matplotlib=3.5.1 Cython=0.29.28 \
+RUN conda install -y --solver=libmamba -c conda-forge -c plant plant=0.1.89dev isce2=2.6.2 matplotlib=3.5.1 Cython=0.29.28 \
     numba=0.55.1 pygeos=0.14.0 pyproj=3.4.1 rasterio=1.3.6 && \
     pip uninstall -y jupyter_server_terminals && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \

--- a/base_images/isce2/docker/Dockerfile
+++ b/base_images/isce2/docker/Dockerfile
@@ -36,8 +36,8 @@ RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
 
 # need to uninstall jupyter_server_terminals as it conflicts with Jupyterlab 3.4.x. Doesn't seem to break anything
 # but can get rid of if/when we upgrade jlab
-RUN conda install -y --solver=libmamba -c conda-forge -c plant plant=0.1.89dev isce2=2.6.2 matplotlib=3.5.1 Cython=0.29.28 \
-    numba=0.55.1 pygeos=0.14.0 pyproj=3.4.1 rasterio=1.3.6 && \
+RUN conda install -y --solver=libmamba -c conda-forge -c plant plant=0.1.89dev isce2=2.6.2 matplotlib=3.6.2 Cython=0.29.33 \
+    numba=0.56.4 pygeos=0.14 pyproj=3.4.1 rasterio=1.3.4 && \
     pip uninstall -y jupyter_server_terminals && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \

--- a/base_images/isce3/docker/Dockerfile
+++ b/base_images/isce3/docker/Dockerfile
@@ -16,10 +16,11 @@ RUN mkdir /projects
 WORKDIR /projects
 RUN sed -i -e 's/\/root/\/projects/g' /etc/passwd
 
-RUN conda install -y -c conda-forge mamba=1.4.2
-RUN pip install pyOpenSSL==23.2.0
+RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
+    conda install -y -n base conda-libmamba-solver && \
+    conda config --set solver libmamba
 
-RUN mamba install -y -c conda-forge isce3=0.12.0 xarray=2023.4.2 \
+RUN conda install -y --solver=libmamba -c conda-forge isce3=0.12.0 xarray=2023.4.2 \
     hvplot=0.8.3 fsspec=2023.5.0 scikit-learn=1.2.2 && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \

--- a/base_images/pangeo/docker/Dockerfile
+++ b/base_images/pangeo/docker/Dockerfile
@@ -13,8 +13,11 @@ RUN mkdir /projects
 WORKDIR /projects
 RUN sed -i -e 's/\/root/\/projects/g' /etc/passwd
 
-RUN conda install -c conda-forge mamba && \
-    mamba install -c conda-forge -y gdal=3.6.2 matplotlib=3.6.2 Cython=0.29.33 h5py=3.7.0 numba=0.56.4 \
+RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
+    conda install -y -n base conda-libmamba-solver && \
+    conda config --set solver libmamba
+
+RUN conda install -y --solver=libmamba -c conda-forge gdal=3.6.2 matplotlib=3.6.2 Cython=0.29.33 h5py=3.7.0 numba=0.56.4 \
     pygeos=0.14 pyproj=3.4.1 rasterio=1.3.4 scipy=1.10.0 \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.js.map' -delete \

--- a/base_images/r/docker/Dockerfile
+++ b/base_images/r/docker/Dockerfile
@@ -16,10 +16,11 @@ RUN mkdir /projects
 WORKDIR /projects
 RUN sed -i -e 's/\/root/\/projects/g' /etc/passwd
 
-RUN conda install -y -c conda-forge mamba=1.3.1
-RUN pip install pyOpenSSL==23.2.0
+RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
+    conda install -y -n base conda-libmamba-solver && \
+    conda config --set solver libmamba
 
-RUN mamba install -y -c conda-forge r==4.2 r-rgdal==1.5_32 r-sf==1.0_7 r-irkernel==1.3.2 r-gridExtra==2.3 \
+RUN conda install -y --solver=libmamba -c conda-forge r==4.2 r-rgdal==1.5_32 r-sf==1.0_7 r-irkernel==1.3.2 r-gridExtra==2.3 \
     r-tidyverse==2.0.0 r-randomForest==4.7_1.1 r-raster==3.6_20 r-data.table==1.14.8 r-rlist==0.4.6.2 \
     r-gdalutils==2.0.3.2 r-stringr==1.5.0 && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \

--- a/base_images/rgedi/docker/Dockerfile
+++ b/base_images/rgedi/docker/Dockerfile
@@ -1,7 +1,4 @@
-FROM continuumio/miniconda3:22.11.1
-ENV LANG en_US.UTF-8
-ENV TZ US/Pacific
-ARG DEBIAN_FRONTEND=noninteractive
+FROM continuumio/miniconda3:4.12.0
 
 # install maap-py library
 ENV MAAP_CONF='/maap-py/'

--- a/base_images/rgedi/docker/Dockerfile
+++ b/base_images/rgedi/docker/Dockerfile
@@ -11,9 +11,13 @@ WORKDIR /projects
 RUN sed -i -e 's/\/root/\/projects/g' /etc/passwd && echo "source activate r-with-gdal" > ~/.bashrc
 RUN apt-get update && apt-get install -y libxt-dev && apt-get clean
 
-RUN conda install -y -c conda-forge mamba && \
-    mamba install -y -c conda-forge nb_conda_kernels
-RUN mamba create --name r-with-gdal -c conda-forge -c r -c csdms-stack gdal r-rgdal r-sf r-irkernel r-gridExtra r-tidyverse \
+RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
+    conda install -y -n base conda-libmamba-solver && \
+    conda config --set solver libmamba
+
+RUN conda install -y --solver=libmamba -c conda-forge nb_conda_kernels
+
+RUN conda create --name r-with-gdal --solver=libmamba -c conda-forge -c r -c csdms-stack gdal r-rgdal r-sf r-irkernel r-gridExtra r-tidyverse \
     r-randomForest r-raster r-data.table r-rlist r-gdalutils r-stringr r-devtools sysroot_linux-64=2.17 gcc r-lwgeom szip --yes && \
     /opt/conda/bin/conda clean -afy
 RUN mkdir -p ~/.R/ && echo "LDFLAGS=-lproj" >> ~/.R/Makevars && \

--- a/base_images/rgedi/docker/Dockerfile
+++ b/base_images/rgedi/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM continuumio/miniconda3:4.12.0
+FROM continuumio/miniconda3:22.11.1
+ENV LANG en_US.UTF-8
+ENV TZ US/Pacific
+ARG DEBIAN_FRONTEND=noninteractive
 
 # install maap-py library
 ENV MAAP_CONF='/maap-py/'

--- a/base_images/vanilla/docker/Dockerfile
+++ b/base_images/vanilla/docker/Dockerfile
@@ -17,11 +17,17 @@ RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
     conda install -y -n base conda-libmamba-solver && \
     conda config --set solver libmamba
 
-RUN conda install -y --solver=libmamba -c conda-forge gdal=3.4.1 matplotlib=3.5.1 Cython=0.29.28 h5py=3.6.0 numba=0.55.1 \
-    pygeos=0.12.0 pyproj=3.3.0 rasterio=1.2.10 scipy=1.8.0 && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy
+RUN conda install -y --solver=libmamba -c conda-forge gdal=3.6.2 matplotlib=3.6.2 Cython=0.29.33 h5py=3.7.0 numba=0.56.4 \
+    pygeos=0.14 pyproj=3.4.1 rasterio=1.3.4 scipy=1.10.0 \
+    && find /opt/conda/ -follow -type f -name '*.a' -delete \
+    && find /opt/conda/ -follow -type f -name '*.js.map' -delete \
+    && /opt/conda/bin/conda clean -afy
+
+#RUN conda install -y --solver=libmamba -c conda-forge gdal=3.4.1 matplotlib=3.5.1 Cython=0.29.28 h5py=3.6.0 numba=0.55.1 \
+#    pygeos=0.12.0 pyproj=3.3.0 rasterio=1.2.10 scipy=1.8.0 && \
+#    find /opt/conda/ -follow -type f -name '*.a' -delete && \
+#    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
+#    /opt/conda/bin/conda clean -afy
 
 ARG IMAGE_REF
 ENV DOCKERIMAGE_PATH=${IMAGE_REF}

--- a/base_images/vanilla/docker/Dockerfile
+++ b/base_images/vanilla/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
     conda install -y -n base conda-libmamba-solver && \
     conda config --set solver libmamba
 
-RUN conda install -y --solver=libmamba -c conda-forge gdal=3.6.2 matplotlib=3.6.2 Cython=0.29.33 h5py=3.7.0 numba=0.56.4 \
+RUN conda install -y --solver=libmamba -c conda-forge gdal=3.4.1 matplotlib=3.5.1 Cython=0.29.28 h5py=3.6.0 numba=0.55.1 \
     pygeos=0.14 pyproj=3.4.1 rasterio=1.3.4 scipy=1.10.0 \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.js.map' -delete \

--- a/base_images/vanilla/docker/Dockerfile
+++ b/base_images/vanilla/docker/Dockerfile
@@ -10,8 +10,11 @@ RUN mkdir /projects
 WORKDIR /projects
 RUN sed -i -e 's/\/root/\/projects/g' /etc/passwd
 
-RUN conda install -c conda-forge mamba && \
-    mamba install -c conda-forge -y gdal=3.4.1 matplotlib=3.5.1 Cython=0.29.28 h5py=3.6.0 numba=0.55.1 \
+RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
+    conda install -y -n base conda-libmamba-solver && \
+    conda config --set solver libmamba
+
+RUN conda install -y --solver=libmamba -c conda-forge gdal=3.4.1 matplotlib=3.5.1 Cython=0.29.28 h5py=3.6.0 numba=0.55.1 \
     pygeos=0.12.0 pyproj=3.3.0 rasterio=1.2.10 scipy=1.8.0 && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \

--- a/base_images/vanilla/docker/Dockerfile
+++ b/base_images/vanilla/docker/Dockerfile
@@ -1,4 +1,7 @@
 FROM continuumio/miniconda3:22.11.1
+ENV LANG en_US.UTF-8
+ENV TZ US/Pacific
+ARG DEBIAN_FRONTEND=noninteractive
 
 # install maap-py library
 ENV MAAP_CONF='/maap-py/'

--- a/base_images/vanilla/docker/Dockerfile
+++ b/base_images/vanilla/docker/Dockerfile
@@ -17,17 +17,11 @@ RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
     conda install -y -n base conda-libmamba-solver && \
     conda config --set solver libmamba
 
-RUN conda install -y --solver=libmamba -c conda-forge gdal=3.4.1 matplotlib=3.5.1 Cython=0.29.28 h5py=3.6.0 numba=0.55.1 \
+RUN conda install -y --solver=libmamba -c conda-forge gdal=3.6.2 matplotlib=3.6.2 Cython=0.29.33 h5py=3.7.0 numba=0.56.4 \
     pygeos=0.14 pyproj=3.4.1 rasterio=1.3.4 scipy=1.10.0 \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.js.map' -delete \
     && /opt/conda/bin/conda clean -afy
-
-#RUN conda install -y --solver=libmamba -c conda-forge gdal=3.4.1 matplotlib=3.5.1 Cython=0.29.28 h5py=3.6.0 numba=0.55.1 \
-#    pygeos=0.12.0 pyproj=3.3.0 rasterio=1.2.10 scipy=1.8.0 && \
-#    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-#    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-#    /opt/conda/bin/conda clean -afy
 
 ARG IMAGE_REF
 ENV DOCKERIMAGE_PATH=${IMAGE_REF}

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -58,7 +58,7 @@ RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.1.1 --no-build
 RUN jupyter labextension install @maap-jupyterlab/umf-jupyter-extension@1.0.0 --no-build
-RUN jupyter labextension install @maap-jupyterlab/maap-libs-jupyter-extension@1.0.0 --no-build
+RUN jupyter labextension install @maap-jupyterlab/maap-libs-jupyter-extension@1.0.1 --no-build
 RUN jupyter labextension install @maap-jupyterlab/edsc-jupyter-extension@1.0.4 --no-build
 RUN jupyter labextension install @maap-jupyterlab/user-workspace-management-jupyter-extension@0.0.3 --no-build
 RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@0.0.46 --no-build

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN jupyter labextension install @maap-jupyterlab/umf-jupyter-extension@1.0.0 --
 RUN jupyter labextension install @maap-jupyterlab/maap-libs-jupyter-extension@1.0.2 --no-build
 RUN jupyter labextension install @maap-jupyterlab/edsc-jupyter-extension@1.0.4 --no-build
 RUN jupyter labextension install @maap-jupyterlab/user-workspace-management-jupyter-extension@0.0.3 --no-build
-RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@1.0.0 --no-build
+RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@0.0.46 --no-build
 RUN jupyter labextension install @maap-jupyterlab/che-sidebar-visibility-jupyter-extension@1.0.1 --no-build
 
 RUN jupyter lab build && \

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN jupyter labextension install @maap-jupyterlab/umf-jupyter-extension@1.0.0 --
 RUN jupyter labextension install @maap-jupyterlab/maap-libs-jupyter-extension@1.0.2 --no-build
 RUN jupyter labextension install @maap-jupyterlab/edsc-jupyter-extension@1.0.4 --no-build
 RUN jupyter labextension install @maap-jupyterlab/user-workspace-management-jupyter-extension@0.0.3 --no-build
-RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@0.0.46 --no-build
+RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@1.0.0 --no-build
 RUN jupyter labextension install @maap-jupyterlab/che-sidebar-visibility-jupyter-extension@1.0.1 --no-build
 
 RUN jupyter lab build && \

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -23,10 +23,10 @@ RUN apt-get clean && apt-get update && \
 RUN echo "Checking if environment.yml exists for ${BASE_IMAGE_TYPE}" \
     ; if [ -f "/${BASE_IMAGE_TYPE}/environment.yml" ]; then \
         echo "Installing packages from '/${BASE_IMAGE_TYPE}/environment.yml'" \
-        ; conda env update --name base --file "/${BASE_IMAGE_TYPE}/environment.yml" \
+        ; conda env update --name base --file "/${BASE_IMAGE_TYPE}/environment.yml" --solver libmamba \
     ; else \
         echo "Installing packages from '/shared/environment.yml'" \
-        ; conda env update --name base --file "/shared/environment.yml" \
+        ; conda env update --name base --file "/shared/environment.yml" --solver libmamba \
     ; fi
 
 RUN npm install typescript -g

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -23,10 +23,10 @@ RUN apt-get clean && apt-get update && \
 RUN echo "Checking if environment.yml exists for ${BASE_IMAGE_TYPE}" \
     ; if [ -f "/${BASE_IMAGE_TYPE}/environment.yml" ]; then \
         echo "Installing packages from '/${BASE_IMAGE_TYPE}/environment.yml'" \
-        ; mamba env update --name base --file "/${BASE_IMAGE_TYPE}/environment.yml" \
+        ; conda env update --name base --file "/${BASE_IMAGE_TYPE}/environment.yml" \
     ; else \
         echo "Installing packages from '/shared/environment.yml'" \
-        ; mamba env update --name base --file "/shared/environment.yml" \
+        ; conda env update --name base --file "/shared/environment.yml" \
     ; fi
 
 RUN npm install typescript -g

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
 ###############################
 # Custom Jupyter Extensions
 ###############################
-RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.4.0 --no-build
+RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.4.6 --no-build
 
 # PyPi package prepended with 'maap' so it more easily discoverable
 RUN pip install maap-jupyter-server-extension==1.1.1


### PR DESCRIPTION
- no longer using mamba
- now using conda with libmamba solver 
- updated versions of base_images/vanilla packages to be consistent with higher level package versions that base_images/pangeo was using because I was getting dependency errors 
- isce2 and rgedi going to be removed, but edited them anyway to be consistent 
- all base_images starting out with 
```
RUN conda install -y -c conda-forge pyOpenSSL=23.2.0 && \
    conda install -y -n base conda-libmamba-solver && \
    conda config --set solver libmamba
```
to be consistent across 
Note that `conda install -y -c conda-forge pyOpenSSL=23.2.0` fixed a building bug for 3 of the images earlier 
- believed to solve/ reduce `ImportError: libarchive.so.13: cannot open shared object file: No such file or directory` when building images
- Added
```
ENV LANG en_US.UTF-8
ENV TZ US/Pacific
ARG DEBIAN_FRONTEND=noninteractive
``` 
to the beginning of base_images/vanilla to be consistent 
- built both `develop` and `feature/libmamba-solver` branches and times were
vanilla: 14 minutes 11 seconds (libmamba) vs 23 minutes and 18 seconds (develop)
isce3: 25 minutes 17 seconds (libmamba) vs 14 minutes 6 seconds (develop)
r: 16 minutes 53 seconds (libmamba) vs 24 minutes and 52 seconds (develop)
pangeo: 14 minutes 53 seconds (libmamba) vs 15 minutes 49 seconds (develop)


- Find successful build of 4 relevant images here: https://repo.dit.maap-project.org/root/maap-workspaces/-/pipelines/3650 
Note that isce2 is failing to build with dependency issues, but in the 9/20 hackathon we decided it wasn't worth trying to fix 
I got rGEDI to work one time here: https://repo.dit.maap-project.org/root/maap-workspaces/-/pipelines/3669, but then it kept failing later so I just removed [the fix](https://github.com/MAAP-Project/maap-workspaces/commit/f9ee723f135f486ca62c9f28a82722f260ad8a68)
I can keep working on fixing rGEDI, but I didn't think it was worth the time since we decided to get rid of it 
Find build of develop here for comparisons: https://repo.dit.maap-project.org/root/maap-workspaces/-/pipelines/3659 

@anilnatha noticed that libmamba solver is ignoring the nodefaults channel tag in the .yml file and it is a bug others have noticed. In the hackathon we decided to just let it be for now and libmamba solver will become even faster once this bug is fixed 

Also, Alex mentioned we should freeze isce2 and rgedi on a working image and this PR fails for both those images so maybe we freeze those images before merging this PR? Again, I tried briefly to get isce2 and rgedi working but wasn't sure it was worth the time 

Updating documentation to tell users to use `conda install` instead of `mamba install`