### PR TITLE
Bug/jlab launch error

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.9 --
 
 # PyPi package prepended with 'maap' so it more easily discoverable
 #RUN pip install maap-jupyter-server-extension==1.2.2
-RUN jupyter labextension install maap-jupyter-server-extension@1.2.3 --no-build
+RUN pip install --index-url https://test.pypi.org/simple/ maap-jupyter-server-extension==1.2.7
 RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.2.0 --no-build

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -77,11 +77,7 @@ RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.9 --
 
 # PyPi package prepended with 'maap' so it more easily discoverable
 #RUN pip install maap-jupyter-server-extension==1.2.2
-RUN git clone --single-branch --branch bug/pin-jupyter-server https://github.com/MAAP-Project/jupyter-server-extension.git
-RUN cd jupyter-server-extension \
-    && npm install \
-    && npm run build \
-    && jupyter labextension install --no-build
+RUN jupyter labextension install maap-jupyter-server-extension@1.2.3 --no-build
 RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.2.0 --no-build

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.9 --
 
 # PyPi package prepended with 'maap' so it more easily discoverable
 #RUN pip install maap-jupyter-server-extension==1.2.2
-RUN pip install --index-url https://test.pypi.org/simple/ maap-jupyter-server-extension==1.2.9
+RUN pip install maap-jupyter-server-extension==1.2.3
 RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.2.0 --no-build

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -76,7 +76,6 @@ RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
 RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.9 --no-build
 
 # PyPi package prepended with 'maap' so it more easily discoverable
-#RUN pip install maap-jupyter-server-extension==1.2.2
 RUN pip install maap-jupyter-server-extension==1.2.3
 RUN jupyter server extension enable jupyter_server_extension
 

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -76,7 +76,12 @@ RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
 RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.9 --no-build
 
 # PyPi package prepended with 'maap' so it more easily discoverable
-RUN pip install maap-jupyter-server-extension==1.2.2
+#RUN pip install maap-jupyter-server-extension==1.2.2
+RUN git clone --single-branch --branch bug/pin-jupyter-server https://github.com/MAAP-Project/jupyter-server-extension.git
+RUN cd jupyter-server-extension \
+    && npm install \
+    && npm run build \
+    && jupyter labextension install --no-build
 RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.2.0 --no-build

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.9 --
 
 # PyPi package prepended with 'maap' so it more easily discoverable
 #RUN pip install maap-jupyter-server-extension==1.2.2
-RUN pip install --index-url https://test.pypi.org/simple/ maap-jupyter-server-extension==1.2.8
+RUN pip install --index-url https://test.pypi.org/simple/ maap-jupyter-server-extension==1.2.9
 RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.2.0 --no-build

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.9 --
 
 # PyPi package prepended with 'maap' so it more easily discoverable
 #RUN pip install maap-jupyter-server-extension==1.2.2
-RUN pip install --index-url https://test.pypi.org/simple/ maap-jupyter-server-extension==1.2.7
+RUN pip install --index-url https://test.pypi.org/simple/ maap-jupyter-server-extension==1.2.8
 RUN jupyter server extension enable jupyter_server_extension
 
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.2.0 --no-build


### PR DESCRIPTION
Resolved the error causing new workspaces to fail to launch in DIT by pinning the jupyter_server version to 2.12.5  in jupyter-server-extension. jupyter_server v2.13.0 being released then used by us was breaking things, but @bsatoriu knows the fix if we want to use 2.13.0 later 

Can test with image here: 
'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/vanilla:jlab-launch-error'