### PR TITLE
Awscli bug

### DIFF
--- a/base_images/isce3/environment.yml
+++ b/base_images/isce3/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - fsspec=2023.12.2
   - gdal=3.7.0
   - geopandas=0.14.1
-  - groff
+  - groff=1.22.4
   - h5py=3.9.0
   - hdf5=1.14.1
   - httpx=0.25.2

--- a/base_images/isce3/environment.yml
+++ b/base_images/isce3/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - fsspec=2023.12.2
   - gdal=3.7.0
   - geopandas=0.14.1
+  - groff
   - h5py=3.9.0
   - hdf5=1.14.1
   - httpx=0.25.2

--- a/base_images/pangeo/environment.yml
+++ b/base_images/pangeo/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - geocube=0.4.2
   - geopandas=0.14.2
   - geoviews-core=1.11.0
-  - groff
+  - groff=1.22.4
   - h5netcdf=1.3.0
   - h5py=3.9.0
   - hdf5=1.14.0

--- a/base_images/pangeo/environment.yml
+++ b/base_images/pangeo/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - geocube=0.4.2
   - geopandas=0.14.2
   - geoviews-core=1.11.0
+  - groff
   - h5netcdf=1.3.0
   - h5py=3.9.0
   - hdf5=1.14.0

--- a/base_images/r/environment.yml
+++ b/base_images/r/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - awscli=2.14.1
   - earthaccess=0.8.2
-  - groff
+  - groff=1.22.4
   - parallel=20231122
   - perl=5.32.1
   - postgis=3.4.0

--- a/base_images/r/environment.yml
+++ b/base_images/r/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - awscli=2.14.1
   - earthaccess=0.8.2
+  - groff
   - parallel=20231122
   - perl=5.32.1
   - postgis=3.4.0

--- a/base_images/vanilla/environment.yml
+++ b/base_images/vanilla/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - gdal=3.7.0
   - geocube=0.4.2
   - geopandas=0.14.2
-  - groff
+  - groff=1.22.4
   - h5py=3.9.0
   - hdf5=1.14.0
   - httpx=0.26.0

--- a/base_images/vanilla/environment.yml
+++ b/base_images/vanilla/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - gdal=3.7.0
   - geocube=0.4.2
   - geopandas=0.14.2
+  - groff
   - h5py=3.9.0
   - hdf5=1.14.0
   - httpx=0.26.0

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
 ###############################
 # Custom Jupyter Extensions
 ###############################
-RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.2 --no-build
+RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.9 --no-build
 
 # PyPi package prepended with 'maap' so it more easily discoverable
 RUN pip install maap-jupyter-server-extension==1.2.2


### PR DESCRIPTION
Added `groff` to all base_image environment.ymls so that awscli was fixed (used `aws s3 help` as the indicator) 
Tested for vanilla, r, pangeo, and isce3
Test images: 
mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/vanilla:awscli
mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/r:awscli
mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/pangeo:awscli
mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/isce3:awscli