### PR TITLE
changed to use pip install

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -67,7 +67,7 @@ RUN chmod g+w /etc/passwd
 ###############################
 # Non Custom Jupyter Extensions
 ###############################
-RUN pip install plotly@5.5.0
+RUN jupyter labextension install --no-build jupyterlab-plotly@5.5.0
 RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
 
 ###############################

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -67,25 +67,24 @@ RUN chmod g+w /etc/passwd
 ###############################
 # Non Custom Jupyter Extensions
 ###############################
-RUN jupyter labextension install --no-build jupyterlab-plotly@5.5.0
+RUN pip install plotly@5.5.0
 RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
 
 ###############################
 # Custom Jupyter Extensions
 ###############################
-RUN jupyter labextension install @maap-jupyterlab/dps-jupyter-extension@0.5.2 --no-build
 
 # PyPi package prepended with 'maap' so it more easily discoverable
-RUN pip install maap-jupyter-server-extension==1.2.2
+RUN pip install maap-jupyter-server-extension==1.3.0
 RUN jupyter server extension enable jupyter_server_extension
 
+RUN pip install maap-dps-jupyter-extension==0.7.0
 RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.2.0 --no-build
-RUN jupyter labextension install @maap-jupyterlab/umf-jupyter-extension@1.0.0 --no-build
-RUN jupyter labextension install @maap-jupyterlab/maap-libs-jupyter-extension@1.0.2 --no-build
-RUN jupyter labextension install @maap-jupyterlab/edsc-jupyter-extension@1.0.4 --no-build
-RUN jupyter labextension install @maap-jupyterlab/user-workspace-management-jupyter-extension@0.0.5 --no-build
-RUN jupyter labextension install @maap-jupyterlab/maap-help-jupyter-extension@1.0.1 --no-build
-RUN jupyter labextension install @maap-jupyterlab/che-sidebar-visibility-jupyter-extension@1.0.1 --no-build
+RUN pip install maap-libs-jupyter-extension==1.2.0
+RUN pip install maap-edsc-jupyter-extension==1.1.0
+RUN pip install maap-user-workspace-management-jupyter-extension==0.1.0
+RUN pip install maap-help-jupyter-extension==1.3.0
+RUN pip install maap-che-sidebar-visibility-jupyter-extension==1.1.0
 
 RUN jupyter lab build && \
     jupyter lab clean && \

--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -74,16 +74,16 @@ RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
 # Custom Jupyter Extensions
 ###############################
 
-# PyPi package prepended with 'maap' so it more easily discoverable
+# PyPi packages prepended with 'maap' so they are more easily discoverable
 RUN pip install maap-jupyter-server-extension==1.3.0
 RUN jupyter server extension enable jupyter_server_extension
 
 RUN pip install maap-dps-jupyter-extension==0.7.0
-RUN jupyter labextension install @maap-jupyterlab/algorithms_jupyter_extension@0.2.0 --no-build
+RUN pip install maap-algorithms-jupyter-extension==0.3.0
 RUN pip install maap-libs-jupyter-extension==1.2.0
 RUN pip install maap-edsc-jupyter-extension==1.1.0
 RUN pip install maap-user-workspace-management-jupyter-extension==0.1.0
-RUN pip install maap-help-jupyter-extension==1.3.0
+RUN pip install maap-help-jupyter-extension==1.3.1
 RUN pip install maap-che-sidebar-visibility-jupyter-extension==1.1.0
 
 RUN jupyter lab build && \


### PR DESCRIPTION
- updated package installation to use pip install 
- umf extension has been removed since the CMR metadata form is no longer used and there is no equivalent to take its place