### PR TITLE
Update devfile metadata

### DIFF
--- a/devfiles/isce3/devfile/meta.yaml
+++ b/devfiles/isce3/devfile/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: "MAAP ISCE3"
-description: Latest version of MAAP ISCE3
+description: "MAAP ISCE3 Version: 3.1.5"
 tags: ["JupyterLab", "Python", "MAAP", "ISCE3"]
 icon: /devfiles/isce3/devfile/isce.png
 globalMemoryLimit: 2710Mi

--- a/devfiles/pangeo/devfile/meta.yaml
+++ b/devfiles/pangeo/devfile/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: "Pangeo"
-description: "Version: 2023.04.15"
+description: "MAAP Pangeo version: 3.1.5"
 tags: ["Pangeo", "JupyterLab", "MAAP"]
 icon: /devfiles/pangeo/devfile/pangeo_simple_logo.svg
 globalMemoryLimit: 2710Mi

--- a/devfiles/r/devfile/meta.yaml
+++ b/devfiles/r/devfile/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: "MAAP R Stable"
-description: Latest version of MAAP R
+description: "MAAP R version: 3.1.5"
 tags: ["Python", "R", "JupyterLab", "MAAP"]
 icon: /devfiles/r/devfile/r.png
 globalMemoryLimit: 2710Mi

--- a/devfiles/vanilla/devfile/meta.yaml
+++ b/devfiles/vanilla/devfile/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: "Basic Stable"
-description: Latest version of MAAP Basic
+description: "MAAP vanilla version: 3.1.5"
 tags: ["JupyterLab", "Python", "MAAP"]
 icon: /devfiles/vanilla/devfile/jupyter.png
 globalMemoryLimit: 2710Mi


### PR DESCRIPTION
@wildintellect noted that the devfile description for Pangeo appearing in the Get Started tab of the ADE contained an outdated version. This PR updates all the devfiles to include the correct version number to match the convention used in OPS.