### PR TITLE
Extracted out jupyter extensions

### DIFF
--- a/jupyterlab3/docker/Dockerfile
+++ b/jupyterlab3/docker/Dockerfile
@@ -75,16 +75,7 @@ RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements
 ###############################
 
 # PyPi packages prepended with 'maap' so they are more easily discoverable
-RUN pip install maap-jupyter-server-extension==1.3.4
 RUN jupyter server extension enable jupyter_server_extension
-
-RUN pip install maap-dps-jupyter-extension==0.7.0
-RUN pip install maap-algorithms-jupyter-extension==0.3.0
-RUN pip install maap-libs-jupyter-extension==1.2.0
-RUN pip install maap-edsc-jupyter-extension==1.1.0
-RUN pip install maap-user-workspace-management-jupyter-extension==0.1.0
-RUN pip install maap-help-jupyter-extension==1.3.1
-RUN pip install maap-che-sidebar-visibility-jupyter-extension==1.1.0
 
 RUN jupyter lab build && \
     jupyter lab clean && \

--- a/jupyterlab3/pangeo/environment.yml
+++ b/jupyterlab3/pangeo/environment.yml
@@ -36,6 +36,14 @@ dependencies:
     - jupyter-resource-usage==0.7.2
     - rio-tiler==6.2.8
     - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.3.6#egg-info=stac_ipyleaflet
+    - maap-algorithms-jupyter-extension==0.3.0
+    - maap-che-sidebar-visibility-jupyter-extension==1.1.0
+    - maap-dps-jupyter-extension==0.7.0
+    - maap-edsc-jupyter-extension==1.1.0
+    - maap-help-jupyter-extension==1.3.1
+    - maap-jupyter-server-extension==1.3.4
+    - maap-libs-jupyter-extension==1.2.0
+    - maap-user-workspace-management-jupyter-extension==0.1.0
 variables:
   TITILER_STAC_ENDPOINT: 'https://titiler-stac.maap-project.org/'
   TITILER_ENDPOINT: 'https://titiler.maap-project.org/'

--- a/jupyterlab3/shared/environment.yml
+++ b/jupyterlab3/shared/environment.yml
@@ -17,6 +17,14 @@ dependencies:
   - pip:
     - jupyter-resource-usage==0.7.2
     - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.3.6#egg-info=stac_ipyleaflet
+    - maap-algorithms-jupyter-extension==0.3.0
+    - maap-che-sidebar-visibility-jupyter-extension==1.1.0
+    - maap-dps-jupyter-extension==0.7.0
+    - maap-edsc-jupyter-extension==1.1.0
+    - maap-help-jupyter-extension==1.3.1
+    - maap-jupyter-server-extension==1.3.4
+    - maap-libs-jupyter-extension==1.2.0
+    - maap-user-workspace-management-jupyter-extension==0.1.0
 variables:
   TITILER_STAC_ENDPOINT: 'https://titiler-stac.maap-project.org/'
   TITILER_ENDPOINT: 'https://titiler.maap-project.org/'


### PR DESCRIPTION
Extracted the jupyter extensions into the jupyterlab3 environment.ymls

Note I kept:

```
RUN jupyter labextension install --no-build jupyterlab-plotly@5.5.0
RUN jupyter labextension disable @jupyterlab/apputils-extension:announcements

RUN jupyter server extension enable jupyter_server_extension
```
in the jupyterlab3/dockerfile, and I will explore keeping them there when addressing this ticket: https://github.com/MAAP-Project/Community/issues/967

Also, thank you @marjo-luc for changing `jupyter server extension enable jupyter_server_extension` to `jupyter server extension enable maap_jupyter_server_extension` in the next release of jupyter server extension

I generated these images for testing:
mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/vanilla:extract-jupyter-extension-installs (also created for r, pangeo and isce3)