### PR TITLE
Add devfile docker path env vars

### DIFF
--- a/devfiles/isce3/devfile/devfile.yaml
+++ b/devfiles/isce3/devfile/devfile.yaml
@@ -33,6 +33,9 @@ components:
               - name: jupyter
                 image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/isce3:develop'
                 imagePullPolicy: Always
+                env:
+                - name: DOCKERIMAGE_PATH
+                  value: 'mas.dit.maap-project.org/root/maap-workspaces/base_images/isce3:develop'
                 resources:
                   limits:
                     memory: 8096Mi

--- a/devfiles/pangeo/devfile/devfile.yaml
+++ b/devfiles/pangeo/devfile/devfile.yaml
@@ -33,6 +33,9 @@ components:
               - name: jupyter
                 image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/pangeo:develop'
                 imagePullPolicy: Always
+                env:
+                - name: DOCKERIMAGE_PATH
+                  value: 'mas.dit.maap-project.org/root/maap-workspaces/base_images/pangeo:develop'
                 resources:
                   limits:
                     memory: 8096Mi

--- a/devfiles/r/devfile/devfile.yaml
+++ b/devfiles/r/devfile/devfile.yaml
@@ -33,6 +33,9 @@ components:
               - name: jupyter
                 image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/r:develop'
                 imagePullPolicy: Always
+                env:
+                - name: DOCKERIMAGE_PATH
+                  value: 'mas.dit.maap-project.org/root/maap-workspaces/base_images/r:develop'
                 resources:
                   limits:
                     memory: 8096Mi

--- a/devfiles/vanilla/devfile/devfile.yaml
+++ b/devfiles/vanilla/devfile/devfile.yaml
@@ -33,6 +33,9 @@ components:
               - name: jupyter
                 image: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/vanilla:develop'
                 imagePullPolicy: Always
+                env:
+                - name: DOCKERIMAGE_PATH
+                  value: 'mas.dit.maap-project.org/root/maap-workspaces/base_images/vanilla:develop'
                 resources:
                   limits:
                     memory: 8096Mi


### PR DESCRIPTION
Define the `DOCKERIMAGE_PATH` environment variable within all JupyterLab workspace devfiles to provide the correct base image path when registering algorithms.

See: https://github.com/MAAP-Project/Community/issues/869