### PR TITLE
Create devfile_compile.py

### DIFF
--- a/devfiles/devfile_compile.py
+++ b/devfiles/devfile_compile.py
@@ -7,25 +7,27 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 INDEX_FILE = "index.json"
 META_FILE = "meta.yaml"
 
-with open(INDEX_FILE, "w") as myfile:
-    myfile.write("[")
+# Build the index.json dev registry file
+with open(os.path.join(dir_path, INDEX_FILE), "w") as registry_index_file:
+    registry_index_file.write("[")
 
 i = 0
 
 for subdir, dirs, files in os.walk(dir_path):
     for file in files:
         if file == META_FILE:
+            # Append the devfile metadata to the registry index
             print("Updating " + os.path.join(subdir, file))
 
             if i > 0:
-                with open(INDEX_FILE, "a") as myfile:
-                    myfile.write(", ")
+                with open(os.path.join(dir_path, INDEX_FILE), "a") as registry_index_file:
+                    registry_index_file.write(", ")
 
             i += 1
 
-            with open(os.path.join(subdir, file), 'r') as yaml_in, open(INDEX_FILE, "a") as json_out:
+            with open(os.path.join(subdir, file), 'r') as yaml_in, open(os.path.join(dir_path, INDEX_FILE), "a") as json_out:
                 yaml_object = yaml.safe_load(yaml_in) 
                 json.dump(yaml_object, json_out)
 
-with open(INDEX_FILE, "a") as myfile:
-    myfile.write("]")
+with open(os.path.join(dir_path, INDEX_FILE), "a") as registry_index_file:
+    registry_index_file.write("]")

--- a/devfiles/devfile_compile.py
+++ b/devfiles/devfile_compile.py
@@ -1,0 +1,31 @@
+import yaml
+import json
+import os
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+INDEX_FILE = "index.json"
+META_FILE = "meta.yaml"
+
+with open(INDEX_FILE, "w") as myfile:
+    myfile.write("[")
+
+i = 0
+
+for subdir, dirs, files in os.walk(dir_path):
+    for file in files:
+        if file == META_FILE:
+            print("Updating " + os.path.join(subdir, file))
+
+            if i > 0:
+                with open(INDEX_FILE, "a") as myfile:
+                    myfile.write(", ")
+
+            i += 1
+
+            with open(os.path.join(subdir, file), 'r') as yaml_in, open(INDEX_FILE, "a") as json_out:
+                yaml_object = yaml.safe_load(yaml_in) 
+                json.dump(yaml_object, json_out)
+
+with open(INDEX_FILE, "a") as myfile:
+    myfile.write("]")

--- a/devfiles/edav/devfile/meta.yaml
+++ b/devfiles/edav/devfile/meta.yaml
@@ -3,4 +3,6 @@ displayName: "ESA EDAV"
 description: "Latest version of MAAP ESA EDAV"
 tags: ["EDAV", "MAAP"]
 icon: /devfiles/edav/devfile/earth.png
+links: 
+  self: "/devfiles/edav/devfile/devfile.yaml"
 globalMemoryLimit: 2710Mi

--- a/devfiles/isce3/devfile/meta.yaml
+++ b/devfiles/isce3/devfile/meta.yaml
@@ -3,4 +3,6 @@ displayName: "ISCE3"
 description: "ISCE3 workspace version: 3.1.5"
 tags: ["JupyterLab", "Python", "MAAP", "ISCE3"]
 icon: /devfiles/isce3/devfile/isce.png
+links: 
+  self: "/devfiles/isce3/devfile/devfile.yaml"
 globalMemoryLimit: 2710Mi

--- a/devfiles/pangeo/devfile/meta.yaml
+++ b/devfiles/pangeo/devfile/meta.yaml
@@ -3,4 +3,6 @@ displayName: "Pangeo"
 description: "Pangeo workspace version: 3.1.5"
 tags: ["Pangeo", "JupyterLab", "MAAP"]
 icon: /devfiles/pangeo/devfile/pangeo_simple_logo.svg
+links: 
+  self: "/devfiles/pangeo/devfile/devfile.yaml"
 globalMemoryLimit: 2710Mi

--- a/devfiles/python/devfile/meta.yaml
+++ b/devfiles/python/devfile/meta.yaml
@@ -3,4 +3,6 @@ displayName: "Python (default)"
 description: "Python workspace version: 3.1.5"
 tags: ["JupyterLab", "Python", "MAAP"]
 icon: /devfiles/python/devfile/python-logo-generic.svg
+links: 
+  self: "/devfiles/python/devfile/devfile.yaml"
 globalMemoryLimit: 2710Mi

--- a/devfiles/r/devfile/meta.yaml
+++ b/devfiles/r/devfile/meta.yaml
@@ -3,4 +3,6 @@ displayName: "R/Python"
 description: "R/Python workspace version: 3.1.5"
 tags: ["Python", "R", "JupyterLab", "MAAP"]
 icon: /devfiles/r/devfile/r.png
+links: 
+  self: "/devfiles/r/devfile/devfile.yaml"
 globalMemoryLimit: 2710Mi


### PR DESCRIPTION
When changing the name of a workspace, devfiles are not updated in the devfile registry for newly-added folders. This new file, `devfile_compile.py`, is executed after a workspace build to update/add any new workspace definitions using the defined folders in the devfiles directly.

Note this script will not remove any old workspace folders. This is by design to allow for custom workspaces such as edav, which are not currently bundled in the workspaces repo.