### PR TITLE
Algorithm registration links now open in a new tab

### DIFF
--- a/jupyterlab/shared/environment.yml
+++ b/jupyterlab/shared/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pip:
     - jupyter-resource-usage==1.0.2
     - git+https://github.com/MAAP-Project/stac_ipyleaflet.git@0.3.6#egg-info=stac_ipyleaflet
-    - maap-algorithms-jupyter-extension==0.3.1
+    - maap-algorithms-jupyter-extension==0.3.2
     - maap-che-sidebar-visibility-jupyter-extension==1.1.2
     - maap-dps-jupyter-extension==0.7.1
     - maap-edsc-jupyter-extension==1.1.1


### PR DESCRIPTION
Both of these links open in a new tab
<img width="467" alt="Screenshot 2024-07-17 at 3 03 11 PM" src="https://github.com/user-attachments/assets/afdff574-60ce-4316-8b29-8fa4e3e92699">
<img width="542" alt="Screenshot 2024-07-17 at 3 03 30 PM" src="https://github.com/user-attachments/assets/fc849165-1292-4e53-905c-67f0a5f3f7f2">
