### PR TITLE
Feature/update pangeo extensions

### DIFF
--- a/jupyterlab/pangeo/environment.yml
+++ b/jupyterlab/pangeo/environment.yml
@@ -43,8 +43,8 @@ dependencies:
     - maap-edsc-jupyter-extension==1.1.1
     - maap-help-jupyter-extension==2.0.0
     - maap-jupyter-server-extension==2.0.7
-    - maap-libs-jupyter-extension==1.2.3
-    - maap-user-workspace-management-jupyter-extension==0.1.2
+    - maap-libs-jupyter-extension==1.2.4
+    - maap-user-workspace-management-jupyter-extension==0.1.3
 variables:
   TITILER_STAC_ENDPOINT: 'https://titiler-stac.maap-project.org/'
   TITILER_ENDPOINT: 'https://titiler.maap-project.org/'


### PR DESCRIPTION
Update pangeo jupyter extensions to be consistent with shared/environment.yml. This includes changes
- default maap-py instantiation no longer has api host 
- bug fix for getting presigned s3 url

Can test image here: 'mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/pangeo:update-pangeo-extensions'