### PR TITLE
chore: update titiler-stac

### DIFF
--- a/jupyterlab/shared/environment.yml
+++ b/jupyterlab/shared/environment.yml
@@ -27,7 +27,7 @@ dependencies:
     - maap-libs-jupyter-extension==1.2.3
     - maap-user-workspace-management-jupyter-extension==0.1.2
 variables:
-  TITILER_STAC_ENDPOINT: 'https://titiler-stac.maap-project.org/'
+  TITILER_STAC_ENDPOINT: 'https://titiler-pgstac.maap-project.org/'
   TITILER_ENDPOINT: 'https://titiler.maap-project.org/'
   STAC_CATALOG_NAME: 'MAAP STAC'
   STAC_CATALOG_URL: 'https://stac.maap-project.org/'


### PR DESCRIPTION
## Description

We've moved the `/stac` endpoint from the titiler-stac tiler to the titiler-pgstac tiler and plan on tearing down titiler-stac to address a MCP security issue