### PR TITLE
Bumped jupyter-server-ext version

### DIFF
--- a/jupyterlab/shared/environment.yml
+++ b/jupyterlab/shared/environment.yml
@@ -23,7 +23,7 @@ dependencies:
     - maap-dps-jupyter-extension==0.7.1
     - maap-edsc-jupyter-extension==1.1.1
     - maap-help-jupyter-extension==2.0.0
-    - maap-jupyter-server-extension==2.0.8
+    - maap-jupyter-server-extension==2.0.9
     - maap-libs-jupyter-extension==1.2.4
     - maap-user-workspace-management-jupyter-extension==0.1.3
 variables:


### PR DESCRIPTION
Newer version addresses issue with the low number of jobs shown in the jobs ui. 

Image with this newer version:
mas.dit.maap-project.org/root/maap-workspaces/jupyterlab/python:bump-jupyter-server-ext