### PR TITLE
Develop into main for 4.1.1 release 

### DIFF
--- a/base_images/isce3/environment.yml
+++ b/base_images/isce3/environment.yml
@@ -26,7 +26,6 @@ dependencies:
   - numpy=1.26.4
   - pandas=2.2.2
   - pycurl=7.45.1
-  - pygeos=0.14
   - pyogrio=0.6.0
   - pyproj=3.6.1
   - pystac-client=0.7.5 

--- a/base_images/pangeo/environment.yml
+++ b/base_images/pangeo/environment.yml
@@ -69,7 +69,6 @@ dependencies:
   - pycamhd=0.7.0
   - pycurl=7.45.1
   - pydap=3.4.0
-  - pygeos=0.14
   - pyogrio=0.6.0
   - pyproj=3.5.0
   - pystac-client=0.8.0

--- a/base_images/python/environment.yml
+++ b/base_images/python/environment.yml
@@ -27,7 +27,6 @@ dependencies:
   - pandas=2.2.2
   - pandarallel=1.6.5
   - pycurl=7.45.1
-  - pygeos=0.14
   - pyogrio=0.6.0
   - pyproj=3.5.0
   - pystac-client=0.7.5

--- a/base_images/r/environment.yml
+++ b/base_images/r/environment.yml
@@ -31,7 +31,6 @@ dependencies:
   - perl=5.32.1
   - postgis=3.3.3
   - pycurl=7.45.1
-  - pygeos=0.14
   - pyogrio=0.6.0
   - pyproj=3.5.0
   - pystac-client=0.7.5 

--- a/devfiles/isce3/devfile/meta.yaml
+++ b/devfiles/isce3/devfile/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: "ISCE3"
-description: "ISCE3 MAAP workspace (version 4.1.0)"
+description: "ISCE3 MAAP workspace (version 4.1.1)"
 tags: ["JupyterLab", "Python", "MAAP", "ISCE3"]
 icon: /devfiles/isce3/devfile/isce.png
 links: 

--- a/devfiles/pangeo/devfile/meta.yaml
+++ b/devfiles/pangeo/devfile/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: "Pangeo"
-description: "Pangeo MAAP workspace (version 4.1.0)"
+description: "Pangeo MAAP workspace (version 4.1.1)"
 tags: ["Pangeo", "JupyterLab", "MAAP"]
 icon: /devfiles/pangeo/devfile/pangeo_simple_logo.svg
 links: 

--- a/devfiles/python/devfile/meta.yaml
+++ b/devfiles/python/devfile/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: "Python (default)"
-description: "Basic MAAP python workspace (version 4.1.0)"
+description: "Basic MAAP python workspace (version 4.1.1)"
 tags: ["JupyterLab", "Python", "MAAP"]
 icon: /devfiles/python/devfile/python-logo-generic.svg
 links: 

--- a/devfiles/r/devfile/meta.yaml
+++ b/devfiles/r/devfile/meta.yaml
@@ -1,6 +1,6 @@
 ---
 displayName: "R/Python"
-description: "R/Python MAAP workspace (version 4.1.0)"
+description: "R/Python MAAP workspace (version 4.1.1)"
 tags: ["Python", "R", "JupyterLab", "MAAP"]
 icon: /devfiles/r/devfile/r.png
 links: 

--- a/jupyterlab/pangeo/environment.yml
+++ b/jupyterlab/pangeo/environment.yml
@@ -41,7 +41,7 @@ dependencies:
     - maap-dps-jupyter-extension==0.7.1
     - maap-edsc-jupyter-extension==1.1.1
     - maap-help-jupyter-extension==2.0.0
-    - maap-jupyter-server-extension==2.0.8
+    - maap-jupyter-server-extension==2.0.9
     - maap-libs-jupyter-extension==1.2.4
     - maap-user-workspace-management-jupyter-extension==0.1.3
 variables:

--- a/jupyterlab/shared/environment.yml
+++ b/jupyterlab/shared/environment.yml
@@ -23,7 +23,7 @@ dependencies:
     - maap-dps-jupyter-extension==0.7.1
     - maap-edsc-jupyter-extension==1.1.1
     - maap-help-jupyter-extension==2.0.0
-    - maap-jupyter-server-extension==2.0.8
+    - maap-jupyter-server-extension==2.0.9
     - maap-libs-jupyter-extension==1.2.4
     - maap-user-workspace-management-jupyter-extension==0.1.3
 variables:


### PR DESCRIPTION
Includes:
- removing `pygeos` from all base images
- upgrade to jupyter server extension which sets page size back to 200 so user can see 200 most recent jobs in pages 