### PR TITLE
maap-py pointing back to develop

### DIFF
--- a/base_images/isce3/environment.yml
+++ b/base_images/isce3/environment.yml
@@ -51,4 +51,4 @@ dependencies:
   - pip=24.3.1
   - pip:
     - rio-tiler==7.2.2
-    - git+https://github.com/MAAP-Project/maap-py.git@develop
+    - git+https://github.com/MAAP-Project/maap-py.git@v4.2.3a2

--- a/base_images/isce3/environment.yml
+++ b/base_images/isce3/environment.yml
@@ -51,4 +51,4 @@ dependencies:
   - pip=24.3.1
   - pip:
     - rio-tiler==7.2.2
-    - git+https://github.com/MAAP-Project/maap-py.git@v4.2.3a0
+    - git+https://github.com/MAAP-Project/maap-py.git@develop

--- a/base_images/pangeo/environment.yml
+++ b/base_images/pangeo/environment.yml
@@ -118,4 +118,4 @@ dependencies:
     - morecantile==6.1.0
     - rio-tiler==7.2.2
     - streamjoy==0.0.10
-    - git+https://github.com/MAAP-Project/maap-py.git@v4.2.3a0
+    - git+https://github.com/MAAP-Project/maap-py.git@develop

--- a/base_images/pangeo/environment.yml
+++ b/base_images/pangeo/environment.yml
@@ -118,4 +118,4 @@ dependencies:
     - morecantile==6.1.0
     - rio-tiler==7.2.2
     - streamjoy==0.0.10
-    - git+https://github.com/MAAP-Project/maap-py.git@develop
+    - git+https://github.com/MAAP-Project/maap-py.git@v4.2.3a2

--- a/base_images/python/environment.yml
+++ b/base_images/python/environment.yml
@@ -52,4 +52,4 @@ dependencies:
   - pip:
     - morecantile==6.1.0
     - rio-tiler==7.2.2
-    - git+https://github.com/MAAP-Project/maap-py.git@develop
+    - git+https://github.com/MAAP-Project/maap-py.git@v4.2.3a2

--- a/base_images/python/environment.yml
+++ b/base_images/python/environment.yml
@@ -52,4 +52,4 @@ dependencies:
   - pip:
     - morecantile==6.1.0
     - rio-tiler==7.2.2
-    - git+https://github.com/MAAP-Project/maap-py.git@v4.2.3a0
+    - git+https://github.com/MAAP-Project/maap-py.git@develop

--- a/base_images/r/environment.yml
+++ b/base_images/r/environment.yml
@@ -158,4 +158,4 @@ dependencies:
     - grid==0.7.1
     - morecantile==6.1.0
     - rio-tiler==7.2.2
-    - git+https://github.com/MAAP-Project/maap-py.git@v4.2.3a0
+    - git+https://github.com/MAAP-Project/maap-py.git@develop

--- a/base_images/r/environment.yml
+++ b/base_images/r/environment.yml
@@ -158,4 +158,4 @@ dependencies:
     - grid==0.7.1
     - morecantile==6.1.0
     - rio-tiler==7.2.2
-    - git+https://github.com/MAAP-Project/maap-py.git@develop
+    - git+https://github.com/MAAP-Project/maap-py.git@v4.2.3a2


### PR DESCRIPTION
Maap-py pointing back to develop because builds fail otherwise since other tag doesn't exist