### PR TITLE
Add base image type

### DIFF
--- a/base_images/2i2c/build-images.sh
+++ b/base_images/2i2c/build-images.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -ex
+
+# Check required parameters
+if [ -z "$ENV" ]; then
+    echo "Error: ENV variable is required"
+    echo "Usage: ENV=<environment> TAG=<tag> ./build-images.sh Options are DIT, UAT, OPS"
+    echo "Example: ENV=dit TAG=develop ./build-images.sh"
+    exit 1
+fi
+
+if [ -z "$TAG" ]; then
+    echo "Error: TAG variable is required"
+    echo "Usage: ENV=<environment> TAG=<tag> ./build-images.sh DIT images should be tagged as develop and UAT/OPS releases should have numbered tag"
+    echo "Example: ENV=dev TAG=v1.0.0 ./build-images.sh"
+    exit 1
+fi
+
+base_image_dir=$(dirname $0)
+
+# Generate registry base URL based on ENV
+if [ "$ENV" = "ops" ]; then
+    REGISTRY_BASE="mas.maap-project.org"
+else
+    REGISTRY_BASE="mas.${ENV}.maap-project.org"
+fi
+
+# Build r-base first (required for r image)
+echo "Building r-base image first..."
+pushd $base_image_dir/r-base
+
+R_BASE_IMAGE_REF="${REGISTRY_BASE}/root/maap-workspaces/2i2c/r-base:${TAG}"
+echo "Building r-base image: ${R_BASE_IMAGE_REF}"
+
+docker build -t ${R_BASE_IMAGE_REF} --build-arg IMAGE_REF=${R_BASE_IMAGE_REF} -f docker/Dockerfile .
+docker push ${R_BASE_IMAGE_REF}
+
+popd
+echo "$R_BASE_IMAGE_REF" >> built_images.txt
+
+# Define the images to build
+IMAGE_TYPES="isce3 pangeo r"
+
+for IMAGE_TYPE in ${IMAGE_TYPES}; do
+    pushd $base_image_dir/$IMAGE_TYPE
+
+    # Generate the full image reference
+    IMAGE_REF="${REGISTRY_BASE}/root/maap-workspaces/2i2c/${IMAGE_TYPE}:${TAG}"
+
+    echo "Building ${IMAGE_TYPE} image: ${IMAGE_REF}"
+
+    # For R image, pass the r-base image as BASE_IMAGE
+    if [ "$IMAGE_TYPE" = "r" ]; then
+        docker build -t ${IMAGE_REF} --build-arg IMAGE_REF=${IMAGE_REF} --build-arg BASE_IMAGE=${R_BASE_IMAGE_REF} -f docker/Dockerfile .
+    else
+        docker build -t ${IMAGE_REF} --build-arg IMAGE_REF=${IMAGE_REF} -f docker/Dockerfile .
+    fi
+
+    # Push the image, commenting this line out as default 
+    #docker push ${IMAGE_REF}
+
+    popd
+
+    echo "$IMAGE_REF" >> built_images.txt
+done
+
+echo "All images built successfully!"

--- a/base_images/2i2c/build-images.sh
+++ b/base_images/2i2c/build-images.sh
@@ -5,7 +5,7 @@ set -ex
 # Check required parameters
 if [ -z "$ENV" ]; then
     echo "Error: ENV variable is required"
-    echo "Usage: ENV=<environment> TAG=<tag> ./build-images.sh Options are DIT, UAT, OPS"
+    echo "Usage: ENV=<environment> TAG=<tag> ./build-images.sh Options are dit, uat, ops"
     echo "Example: ENV=dit TAG=develop ./build-images.sh"
     exit 1
 fi
@@ -13,7 +13,7 @@ fi
 if [ -z "$TAG" ]; then
     echo "Error: TAG variable is required"
     echo "Usage: ENV=<environment> TAG=<tag> ./build-images.sh DIT images should be tagged as develop and UAT/OPS releases should have numbered tag"
-    echo "Example: ENV=dev TAG=v1.0.0 ./build-images.sh"
+    echo "Example: ENV=dit TAG=develop ./build-images.sh"
     exit 1
 fi
 
@@ -34,13 +34,18 @@ R_BASE_IMAGE_REF="${REGISTRY_BASE}/root/maap-workspaces/2i2c/r-base:${TAG}"
 echo "Building r-base image: ${R_BASE_IMAGE_REF}"
 
 docker build -t ${R_BASE_IMAGE_REF} --build-arg IMAGE_REF=${R_BASE_IMAGE_REF} -f docker/Dockerfile .
-docker push ${R_BASE_IMAGE_REF}
+# manually add this back in
+#docker push ${R_BASE_IMAGE_REF}
 
 popd
 echo "$R_BASE_IMAGE_REF" >> built_images.txt
 
 # Define the images to build
 IMAGE_TYPES="isce3 pangeo r"
+
+DOCKERIMAGE_PATH_DEFAULT="${REGISTRY_BASE}/root/maap-workspaces/2i2c/custom_images/maap_base:${TAG}"
+
+echo "docker image default path $DOCKERIMAGE_PATH_DEFAULT"
 
 for IMAGE_TYPE in ${IMAGE_TYPES}; do
     pushd $base_image_dir/$IMAGE_TYPE
@@ -52,9 +57,9 @@ for IMAGE_TYPE in ${IMAGE_TYPES}; do
 
     # For R image, pass the r-base image as BASE_IMAGE
     if [ "$IMAGE_TYPE" = "r" ]; then
-        docker build -t ${IMAGE_REF} --build-arg IMAGE_REF=${IMAGE_REF} --build-arg BASE_IMAGE=${R_BASE_IMAGE_REF} -f docker/Dockerfile .
+        docker build -t ${IMAGE_REF} --build-arg IMAGE_REF=${IMAGE_REF} --build-arg BASE_IMAGE=${R_BASE_IMAGE_REF} --build-arg DOCKERIMAGE_PATH_DEFAULT=${DOCKERIMAGE_PATH_DEFAULT} -f docker/Dockerfile .
     else
-        docker build -t ${IMAGE_REF} --build-arg IMAGE_REF=${IMAGE_REF} -f docker/Dockerfile .
+        docker build -t ${IMAGE_REF} --build-arg IMAGE_REF=${IMAGE_REF} --build-arg DOCKERIMAGE_PATH_DEFAULT=${DOCKERIMAGE_PATH_DEFAULT} -f docker/Dockerfile .
     fi
 
     # Push the image, commenting this line out as default 

--- a/base_images/2i2c/isce3/docker/Dockerfile
+++ b/base_images/2i2c/isce3/docker/Dockerfile
@@ -26,5 +26,10 @@ COPY scripts/init-user.sh /usr/local/bin/init-user.sh
 RUN chmod +x /usr/local/bin/init-user.sh
 USER ${NB_USER}
 
+ARG IMAGE_REF
+ENV DOCKERIMAGE_PATH_BASE_IMAGE=${IMAGE_REF}
+ARG DEFAULT_DOCKERFILE_PATH
+ENV DOCKERIMAGE_PATH_DEFAULT=${DEFAULT_DOCKERFILE_PATH}
+
 # This script returns control to base image's /srv/start after 
 ENTRYPOINT ["/usr/local/bin/init-user.sh"]

--- a/base_images/2i2c/pangeo/docker/Dockerfile
+++ b/base_images/2i2c/pangeo/docker/Dockerfile
@@ -25,5 +25,10 @@ COPY scripts/init-user.sh /usr/local/bin/init-user.sh
 RUN chmod +x /usr/local/bin/init-user.sh
 USER ${NB_USER}
 
+ARG IMAGE_REF
+ENV DOCKERIMAGE_PATH_BASE_IMAGE=${IMAGE_REF}
+ARG DEFAULT_DOCKERFILE_PATH
+ENV DOCKERIMAGE_PATH_DEFAULT=${DEFAULT_DOCKERFILE_PATH}
+
 # This script returns control to base image's /srv/start after 
 ENTRYPOINT ["/usr/local/bin/init-user.sh"]

--- a/base_images/2i2c/r/docker/Dockerfile
+++ b/base_images/2i2c/r/docker/Dockerfile
@@ -13,3 +13,8 @@ RUN conda env update -n ${CONDA_ENV} -f "/tmp/environment.yml" \
     && ${CONDA_DIR}/bin/conda clean -afy
 
 RUN conda init
+
+ARG IMAGE_REF
+ENV DOCKERIMAGE_PATH_BASE_IMAGE=${IMAGE_REF}
+ARG DEFAULT_DOCKERFILE_PATH
+ENV DOCKERIMAGE_PATH_DEFAULT=${DEFAULT_DOCKERFILE_PATH}

--- a/base_images/2i2c/r/docker/Dockerfile
+++ b/base_images/2i2c/r/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM mas.dit.maap-project.org/root/maap-workspaces/2i2c/r-base:develop
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 ENV LANG=en_US.UTF-8
 ENV TZ=US/Pacific
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
We have to manually tag these env vars for now until we get the CI pipeline set up again to work with 2i2c images 