### PR TITLE
Updated miniforge version for base image

### DIFF
--- a/custom_images/build-image.sh
+++ b/custom_images/build-image.sh
@@ -15,7 +15,7 @@ for dir in "${DIRS_LIST[@]}"; do
     IMAGE_PATH=$(basename "$base_image_dir")
     IMAGE_REF=${CI_REGISTRY_IMAGE}/${IMAGE_PATH}/${IMAGE_NAME}:${BRANCH}
     DEFAULT_DOCKERFILE_PATH=${CI_REGISTRY_IMAGE}/custom_images/maap_base:${BRANCH}
-    docker build -t "${IMAGE_REF}" --build-arg IMAGE_REF="${IMAGE_REF}" --build-arg DEFAULT_DOCKERFILE_PATH=${DEFAULT_DOCKERFILE_PATH} -f docker/Dockerfile .
+    docker buildx build --platform=linux/amd64 -t "${IMAGE_REF}" --build-arg IMAGE_REF="${IMAGE_REF}" --build-arg DEFAULT_DOCKERFILE_PATH=${DEFAULT_DOCKERFILE_PATH} -f docker/Dockerfile .
     docker push "${IMAGE_REF}"
     popd
     echo "$IMAGE_REF" >> built_images.txt

--- a/custom_images/maap_base/docker/Dockerfile
+++ b/custom_images/maap_base/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:11
 
-ARG MINIFORGE_VERSION="24.11.2-1"
+ARG MINIFORGE_VERSION="26.3.2-3"
 RUN apt-get update -y && apt-get install -y vim wget git && \
     apt-get clean all
 


### PR DESCRIPTION
Needed to specify `--platform=linux/amd64` to build
This will be in v6.0.0 image release 